### PR TITLE
Use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ branding:
   icon: 'life-buoy'
   color: 'blue'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'


### PR DESCRIPTION
Starting the last few days, GitHub issues warnings because Node16 actions are deprecated: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20